### PR TITLE
Add gitignore, simplify tmp_ vert processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
Two simple changes as groundwork for another (forthcoming) PR.

First, adds a .gitignore file, so I can add `git add` without accidentally adding `__pycache__`.

Second, rewrites the tmp_shade_cols, etc. code to read the three tri verts (as binary data) and only process them into the attribute arrays after filtering, instead of processing them into temp arrays before filtering. This removes the need to have temp arrays for every single attribute we can create.