### PR TITLE
Import fog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/io_import_glr/__init__.py
+++ b/io_import_glr/__init__.py
@@ -141,6 +141,15 @@ class GLR_OT_ImportGLR(Operator, ImportHelper):
         default=False
     )
 
+    enable_fog: BoolProperty(
+        name='Enable Fog',
+        description=(
+            'Enables fog. The fog effect can also be removed '
+            'after import by deleting the "FogLevel" attribute'
+        ),
+        default=True,
+    )
+
     gen_light_color_attribute: BoolProperty(
         name='Generate \'Lighting\' Color Attribute',
         description='Generate a color attribute which contains all combined lighting colors influencing triangles',
@@ -220,6 +229,7 @@ class GLR_PT_scene(Panel):
         layout.prop(operator, 'enable_srgb')
         layout.prop(operator, 'enable_mat_transparency')
         layout.prop(operator, 'enable_bf_culling')
+        layout.prop(operator, 'enable_fog')
 
 class GLR_PT_colors(Panel):
     bl_space_type = 'FILE_BROWSER'

--- a/io_import_glr/import_glr.py
+++ b/io_import_glr/import_glr.py
@@ -29,7 +29,8 @@ def load(context, **keywords):
             keywords['filter_mode'],
             filter_list,
             keywords['gen_light_color_attribute'],
-            keywords['gen_overlay_color_attribute']
+            keywords['gen_overlay_color_attribute'],
+            keywords['enable_fog'],
         )
         ob = load_glr(filepath, triangle_options)
         obs.append(ob)
@@ -77,6 +78,7 @@ class GlrImporter:
         self.filter_list = triangle_options[3]
         self.gen_light_color_attribute = triangle_options[4]
         self.gen_overlay_color_attribute = triangle_options[5]
+        self.enable_fog = triangle_options[6]
         self.obj_name = None
         self.num_tris = None
         self.microcode = None
@@ -231,7 +233,7 @@ class GlrImporter:
             mesh.vertex_colors.new(name='Light').data.foreach_set('color', light_colors)
         mesh.uv_layers.new(name='UV0').data.foreach_set('uv', uvs0)
         mesh.uv_layers.new(name='UV1').data.foreach_set('uv', uvs1)
-        if any(fog_levels):
+        if self.enable_fog and any(fog_levels):
             mesh.attributes.new(
                 name='FogLevel', type='FLOAT', domain='POINT',
             ).data.foreach_set('value', fog_levels)


### PR DESCRIPTION
Bumps the GLR version to 3 and imports fog.  
Requires #8 as groundwork.  
Companion PR in GLideN64-SceneRipper is https://github.com/Luctaris/GLideN64-SceneRipper/pull/3.

![](https://github.com/Luctaris/blender-import-glr/assets/11024420/4ac72385-8c9a-4fe9-8b2e-6ad38f1748fa)

## How fog works on an N64

Fogging is performed by a cooperation between the RSP (geometry processor) and the RDP (fragment processor). The RDP receives the _fog level_, a value between 0 (no fog) and 1 (full fog), from the RSP in the alpha channel of the vertex color. To use fog, the RDP's blender is configured to lerp between the fragment color and the fog color using the fog level.

    (1 - FogLevel) FragColor + FogLevel FogColor

The _fog color_ is a register on the RDP giving the color at maximum fog level. It is already imported in main as a color attribute named "Fog". Note that it does vary face-to-face, it is not scene-constant. A good example of this is Jolly Roger Bay; the above-water and below-water portions of the level have different fog colors.

![](https://github.com/Luctaris/blender-import-glr/assets/11024420/13c39791-7b4e-41cf-8fbd-53c7ef74914a)

Calculation of the fog level is enabled on the RSP by a flag in the geometry mode register. The fog level is calculated for planes in the viewing frustum parallel to the screen based on the distance between the clipping planes and the _fog position_, the points where the fog starts and stops.

![](https://github.com/Luctaris/blender-import-glr/assets/11024420/c4800e4d-1be1-489f-9a41-fbfed34eee27)

Since this graph is just y=clamp(ax+b), calculation is usually done in terms of a=FogScale and b=FogOffset instead of the fog position directly.

I am not entirely sure if the fog level is calculated at the vertex or fragment level. I currently think it is calculated at the vertex level on a real N64, but GLideN64 can calculate it at the fragment level as an enhancement.

## How fog works in the importer

The fogging formula is easily implemented in the material shader with a Mix node, so the only question is how to import the fog level.

In this PR it is simply baked into a float-type, vertex-domain attribute named "FogLevel".

![](https://github.com/Luctaris/blender-import-glr/assets/11024420/00f93d30-91ff-474b-ad94-df2ad1a598c0)

We could instead just use the vertex color alpha, but (in addition to better readability) a separate attribute has the advantage it can simply be deleted to remove the fog effect, because a missing attribute has everywhere the default value 0 (no fog).

An import option (default on) controls whether fog import is enabled. When fog is disabled, we just skip creating the FogLevel attribute. No change in the shader graph is needed depending on whether fog is enabled or not.

This is a _static fog_ method, meaning the fog does not change as you move around the scene in Blender, but stays where it was when you ripped the scene. The fog level also only increases along the camera axis, instead of radially in all directions like you might expect. There is no fog behind or to the sides of the camera. This is accurate to how it "really works" on the N64.

Example: (The right image is a visualization of the fog level, where 0=blue, 1=red)

![](https://github.com/Luctaris/blender-import-glr/assets/11024420/c95e8d99-db37-4ceb-87f3-d054b7e74b42)