### PR TITLE
Use 0.0 for LOD fraction

### DIFF
--- a/io_import_glr/import_glr.py
+++ b/io_import_glr/import_glr.py
@@ -136,7 +136,7 @@ class GlrImporter:
                 (
                     x, y, z, r, g, b, a, s0, t0, s1, t1,
                 ) = struct.unpack('<11f', fb.read(44))
-                
+
                 # delay writing lists for filter check
                 tmp_shade_cols += [r, g, b, a]
                 tmp_uvs0 += [s0, t0]
@@ -187,7 +187,7 @@ class GlrImporter:
             env_colors += [env_r, env_g, env_b, env_a] * 3
             blend_colors += [blend_r, blend_g, blend_b, blend_a] * 3
             fog_colors += [fog_r, fog_g, fog_b, fog_a] * 3
-            
+
             # Create combination light/overlay color attributes
             # TODO: Implement correctly based on color attributes actively used by each seperate material
             '''
@@ -551,12 +551,21 @@ def make_rdp_input_nodes(mat, sources, tex0, tex1, location):
             input_map[f'{vc} Color'] = node.outputs['Color']
             input_map[f'{vc} Alpha'] = node.outputs['Alpha']
 
+    # LOD Fraction is not implemented; always use 0 for now in
+    # the hopes this will select the highest detail mipmap...
+    for src in ['LOD Fraction', 'Primitive LOD Fraction']:
+        if src in sources:
+            node = nodes.new('ShaderNodeValue')
+            node.name = node.label = src
+            node.location = x, y
+            y -= 200
+            node.outputs['Value'].default_value = 0
+            input_map[src] = node.outputs['Value']
+
     # Not yet implemented
     unimplemented = [
         'Key Center',
         'Key Scale',
-        'LOD Fraction',
-        'Primitive LOD Fraction',
         'Noise',
         'Convert K4',
         'Convert K5',


### PR DESCRIPTION
This fixes the ground in the first level of Banjo-Kazooie.

![](https://github.com/Luctaris/blender-import-glr/assets/11024420/877bde9e-94b0-4b25-804a-b5c47147e527)

The ground uses the LOD Fraction input to blend between two mipmaps

![LodCompare](https://github.com/Luctaris/blender-import-glr/assets/11024420/1d2124e4-c22d-490d-8703-68bd408ecea1)

Currently the LOD fraction is unimplemented, so it was using the cyan color all unimplemented colors use, resulting in the orangish hue shift. This patch still doesn't implement LOD, but just changes the value to scalar 0.0, in the hopes this will be a better fallback.